### PR TITLE
Stage 1: messaging, state, permissions, offscreen scaffold

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,3 +1,91 @@
-chrome.runtime.onInstalled.addListener(() => {
-  console.log('Bug Recorder service worker installed')
+import { onMessage } from '@/lib/messaging'
+import { clearState, getState, setState } from '@/lib/state'
+import type { Status } from '@/types/messages'
+
+const BADGE_ALARM = 'badge-tick'
+const OFFSCREEN_URL = 'src/offscreen/index.html'
+
+async function ensureOffscreen(): Promise<void> {
+  if (await chrome.offscreen.hasDocument()) return
+  await chrome.offscreen.createDocument({
+    url: OFFSCREEN_URL,
+    reasons: [chrome.offscreen.Reason.USER_MEDIA],
+    justification: 'Hosts MediaRecorder for tab screencast.',
+  })
+}
+
+async function closeOffscreen(): Promise<void> {
+  if (await chrome.offscreen.hasDocument()) {
+    await chrome.offscreen.closeDocument()
+  }
+}
+
+async function updateBadge(tabId: number): Promise<void> {
+  const state = await getState()
+  if (!state) {
+    await chrome.action.setBadgeText({ text: '', tabId })
+    return
+  }
+  const elapsed = Math.floor((Date.now() - state.startedAt) / 1000)
+  const minutes = Math.floor(elapsed / 60)
+  const seconds = String(elapsed % 60).padStart(2, '0')
+  await chrome.action.setBadgeText({ text: `${minutes}:${seconds}`, tabId })
+  await chrome.action.setBadgeBackgroundColor({ color: '#ec235a', tabId })
+}
+
+async function start(tabId: number, originPattern: string): Promise<void> {
+  await setState({ tabId, startedAt: Date.now(), originPattern })
+  await ensureOffscreen()
+  await chrome.alarms.create(BADGE_ALARM, { periodInMinutes: 1 / 60 })
+  await updateBadge(tabId)
+  console.log('[bug-recorder] start', { tabId, originPattern })
+}
+
+async function stop(): Promise<void> {
+  const state = await getState()
+  await clearState()
+  await chrome.alarms.clear(BADGE_ALARM)
+  if (state) {
+    await chrome.action.setBadgeText({ text: '', tabId: state.tabId })
+  }
+  await closeOffscreen()
+  console.log('[bug-recorder] stop')
+}
+
+onMessage(async msg => {
+  switch (msg.type) {
+    case 'START':
+      await start(msg.tabId, msg.originPattern)
+      return
+    case 'STOP':
+      await stop()
+      return
+    case 'GET_STATUS': {
+      const state = await getState()
+      const status: Status = state
+        ? { recording: true, ...state }
+        : { recording: false }
+      return status
+    }
+  }
 })
+
+chrome.alarms.onAlarm.addListener(async alarm => {
+  if (alarm.name !== BADGE_ALARM) return
+  const state = await getState()
+  if (!state) {
+    await chrome.alarms.clear(BADGE_ALARM)
+    return
+  }
+  await updateBadge(state.tabId)
+})
+
+chrome.tabs.onRemoved.addListener(async tabId => {
+  const state = await getState()
+  if (state && state.tabId === tabId) {
+    console.log('[bug-recorder] tab closed during recording — cancelling')
+    await stop()
+  }
+})
+
+console.log('[bug-recorder] service worker loaded')

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -1,0 +1,19 @@
+import type { Request } from '@/types/messages'
+
+export function sendMessage<R = unknown>(message: Request): Promise<R> {
+  return chrome.runtime.sendMessage(message)
+}
+
+type Handler = (msg: Request) => Promise<unknown>
+
+export function onMessage(handler: Handler): void {
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    handler(msg as Request)
+      .then(sendResponse)
+      .catch(err => {
+        console.error('[bug-recorder] message handler error', err)
+        sendResponse(undefined)
+      })
+    return true
+  })
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,30 @@
+const RECORDER_PERMISSIONS = ['debugger', 'tabCapture'] as const
+
+export function originPattern(url: string): string {
+  const u = new URL(url)
+  return `${u.protocol}//${u.hostname}/*`
+}
+
+export function isRecordableUrl(url: string | undefined): boolean {
+  if (!url) return false
+  try {
+    const u = new URL(url)
+    return u.protocol === 'http:' || u.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export function requestRecorderPermissions(origin: string): Promise<boolean> {
+  return chrome.permissions.request({
+    permissions: [...RECORDER_PERMISSIONS],
+    origins: [origin],
+  })
+}
+
+export function hasRecorderPermissions(origin: string): Promise<boolean> {
+  return chrome.permissions.contains({
+    permissions: [...RECORDER_PERMISSIONS],
+    origins: [origin],
+  })
+}

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,0 +1,20 @@
+export type RecordingState = {
+  tabId: number
+  startedAt: number
+  originPattern: string
+}
+
+const KEY = 'recordingState'
+
+export async function getState(): Promise<RecordingState | null> {
+  const result = await chrome.storage.session.get(KEY)
+  return (result[KEY] as RecordingState | undefined) ?? null
+}
+
+export async function setState(state: RecordingState): Promise<void> {
+  await chrome.storage.session.set({ [KEY]: state })
+}
+
+export async function clearState(): Promise<void> {
+  await chrome.storage.session.remove(KEY)
+}

--- a/src/offscreen/index.html
+++ b/src/offscreen/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Bug Recorder offscreen</title>
+  </head>
+  <body>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -1,0 +1,1 @@
+console.log('[bug-recorder] offscreen document loaded')

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1,8 +1,101 @@
+import { useEffect, useState } from 'react'
+import { sendMessage } from '@/lib/messaging'
+import {
+  isRecordableUrl,
+  originPattern,
+  requestRecorderPermissions,
+} from '@/lib/permissions'
+import type { Status } from '@/types/messages'
+
+type UiState =
+  | { kind: 'loading' }
+  | { kind: 'unsupported'; reason: string }
+  | { kind: 'idle'; tab: chrome.tabs.Tab; deniedOnce: boolean }
+  | { kind: 'recording' }
+
 export default function App() {
+  const [ui, setUi] = useState<UiState>({ kind: 'loading' })
+
+  useEffect(() => {
+    void load()
+  }, [])
+
+  async function load() {
+    const status = await sendMessage<Status>({ type: 'GET_STATUS' })
+    if (status?.recording) {
+      setUi({ kind: 'recording' })
+      return
+    }
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true })
+    if (!tab || !isRecordableUrl(tab.url)) {
+      setUi({
+        kind: 'unsupported',
+        reason: 'Open a regular http(s) page to record.',
+      })
+      return
+    }
+    setUi({ kind: 'idle', tab, deniedOnce: false })
+  }
+
+  async function start(tab: chrome.tabs.Tab) {
+    if (!tab.id || !tab.url) return
+    const pattern = originPattern(tab.url)
+    const granted = await requestRecorderPermissions(pattern)
+    if (!granted) {
+      setUi({ kind: 'idle', tab, deniedOnce: true })
+      return
+    }
+    await sendMessage({
+      type: 'START',
+      tabId: tab.id,
+      originPattern: pattern,
+    })
+    window.close()
+  }
+
+  async function stop() {
+    await sendMessage({ type: 'STOP' })
+    window.close()
+  }
+
+  if (ui.kind === 'loading') {
+    return (
+      <div className="popup">
+        <p className="caption">Loading…</p>
+      </div>
+    )
+  }
+
+  if (ui.kind === 'unsupported') {
+    return (
+      <div className="popup">
+        <h1>Bug Recorder</h1>
+        <p className="caption">{ui.reason}</p>
+      </div>
+    )
+  }
+
+  if (ui.kind === 'recording') {
+    return (
+      <div className="popup">
+        <button className="btn btn-stop" onClick={stop}>
+          Stop recording
+        </button>
+        <p className="caption">Click when you have reproduced the bug.</p>
+      </div>
+    )
+  }
+
   return (
     <div className="popup">
-      <h1>Bug Recorder</h1>
-      <p className="caption">Scaffold ready — UI coming in stage 1.</p>
+      <button className="btn btn-start" onClick={() => start(ui.tab)}>
+        Start recording
+      </button>
+      <p className="caption">
+        {ui.deniedOnce
+          ? 'Permissions are required to record. Click Start again.'
+          : 'This will reload the page and start recording.'}
+      </p>
     </div>
   )
 }

--- a/src/popup/index.css
+++ b/src/popup/index.css
@@ -22,7 +22,36 @@ body {
 }
 
 .popup .caption {
-  margin: 0;
+  margin: 12px 0 0;
   color: #666;
   font-size: 12px;
+}
+
+.btn {
+  width: 180px;
+  height: 36px;
+  border: none;
+  border-radius: 18px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.btn-start {
+  background: #f5f5f5;
+  color: #ec235a;
+}
+
+.btn-start:hover {
+  background: #ebebeb;
+}
+
+.btn-stop {
+  background: #ec235a;
+  color: #fff;
+}
+
+.btn-stop:hover {
+  background: #d61e51;
 }

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,0 +1,19 @@
+export type StartRequest = {
+  type: 'START'
+  tabId: number
+  originPattern: string
+}
+
+export type StopRequest = {
+  type: 'STOP'
+}
+
+export type GetStatusRequest = {
+  type: 'GET_STATUS'
+}
+
+export type Request = StartRequest | StopRequest | GetStatusRequest
+
+export type Status =
+  | { recording: false }
+  | { recording: true; tabId: number; startedAt: number; originPattern: string }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,11 +17,16 @@ export default defineConfig({
     crx({ manifest }),
     zip({ outDir: 'release', outFileName: `crx-${name}-${version}.zip` }),
   ],
+  build: {
+    rollupOptions: {
+      input: {
+        offscreen: 'src/offscreen/index.html',
+      },
+    },
+  },
   server: {
     cors: {
-      origin: [
-        /chrome-extension:\/\//,
-      ],
+      origin: [/chrome-extension:\/\//],
     },
   },
 })


### PR DESCRIPTION
Cross-context plumbing for the rewrite. No actual recording yet — Stages 2–5 will add tabCapture+MediaRecorder in the offscreen document, CDP-based HAR/console, and the zip assembly. This PR makes the START/STOP flow round-trip cleanly between popup, service worker, and offscreen.

## What's in this PR

**New shared code**
- `src/types/messages.ts` — `Request` discriminated union (`START`, `STOP`, `GET_STATUS`) + `Status` response type
- `src/lib/messaging.ts` — typed `sendMessage<R>()` and `onMessage(handler)` wrappers (async response via `return true`)
- `src/lib/state.ts` — `getState`/`setState`/`clearState` over `chrome.storage.session`, so recording state survives service-worker suspension
- `src/lib/permissions.ts` — `originPattern(url)` to derive `*://example.com/*`, plus `requestRecorderPermissions(origin)` / `hasRecorderPermissions(origin)`

**Service worker (`src/background/index.ts`)**
- Handles `START`: writes session state, ensures offscreen document exists, starts `chrome.alarms` badge tick, sets badge text
- Handles `STOP`: clears state and alarm, clears badge, closes offscreen document
- Handles `GET_STATUS`: returns recording state for the popup
- Listens to `chrome.tabs.onRemoved`: if the recording tab is closed, cancels the session

**Offscreen scaffold**
- `src/offscreen/index.html` + `src/offscreen/index.ts` — empty document that just logs on load. Wired through `vite.config.ts` rollup input so CRXJS bundles it. Stage 2 will add the MediaRecorder here.

**Popup (`src/popup/App.tsx`)**
- Three render states: `idle` (with optional "permissions denied, try again" caption), `recording`, `unsupported` (for `chrome://` etc.)
- On `Start` click: derives origin pattern from active tab URL and calls `chrome.permissions.request({ permissions: ['debugger', 'tabCapture'], origins: [pattern] })`. The user sees one dialog scoped to the current site rather than "all websites". If denied, the popup stays open with a retry caption.
- Closes itself with `window.close()` after dispatching START/STOP so the action badge takes over as the live status indicator.

## Test plan
- [x] `pnpm install && pnpm build` succeed; offscreen ends up at `dist/src/offscreen/index.html` and the service worker loader at `dist/service-worker-loader.js`
- [x] `tsc -b` passes with no errors
- [ ] Manual in `chrome://extensions` (Load unpacked → `dist/`):
  - [ ] Popup opens, shows "Start recording" on a regular http(s) page
  - [ ] Popup shows the unsupported caption on `chrome://extensions`
  - [ ] Click Start on a real page → single Chrome dialog for debugger + tabCapture + the specific origin only
  - [ ] Deny → popup shows the retry caption, no crash
  - [ ] Allow → popup closes, action badge shows `0:01`, `0:02`, … ticking every second
  - [ ] Reopen popup → shows "Stop recording"
  - [ ] Click Stop → badge clears, popup closes
  - [ ] Start, then close the tab → badge clears automatically, state cleaned up

## What's not in this PR
- Stage 2: tabCapture stream → MediaRecorder in offscreen → blob back to SW
- Stage 3: `chrome.debugger.attach` + Network domain → HAR via `chrome-har` npm (fixes the cached-resource timing bug)
- Stage 4: console + exceptions via `Runtime.consoleAPICalled` / `Runtime.exceptionThrown`
- Stage 5: screenshot + meta.json
- Stage 6: zip assembly + download from offscreen via `<a download>` (so no `downloads` permission needed)
- Stage 7: 10-minute cap, debugger `onDetach` cancellation, SW restart recovery
- Stage 8: ESLint flat config, GitHub Actions CI, Web Store release workflow

https://claude.ai/code/session_017HbCsooFaMcc15JCHrbbj3

---
_Generated by [Claude Code](https://claude.ai/code/session_017HbCsooFaMcc15JCHrbbj3)_